### PR TITLE
Fix CryptoCompare APIKey property

### DIFF
--- a/cryptocompare.pas
+++ b/cryptocompare.pas
@@ -27,7 +27,7 @@ type
     function IsRelevant: Boolean; 
     procedure CheckRelevance;
     procedure UpdateData;
-    property APYKey: String read FAPIKey write FAPIKey;
+    property APIKey: String read FAPIKey write FAPIKey;
     property CryptoCompare[aCodeIn: String; aCodeOut: String]: Double read GetCryptoCompare;
     property JSONReply: TJSONObject read GetJSONReply;
   end;

--- a/example/cryptocompareform.pas
+++ b/example/cryptocompareform.pas
@@ -47,7 +47,7 @@ uses
 
 procedure TForm1.BtnGetClick(Sender: TObject);
 begin
-  _CryptoCompare.APYKey:=EdtToken.Text;
+  _CryptoCompare.APIKey:=EdtToken.Text;
   EdtRate.Text:=FloatToStr(_CryptoCompare.CryptoCompare[CmbBxIn.Text, CmbBxOut.Text]);
   Memo1.Text:=_CryptoCompare.JSONReply.FormatJSON();
 end;


### PR DESCRIPTION
## Summary
- fix typo in `TCryptoCompare` property name
- update example to use `APIKey`
